### PR TITLE
allow userId of middleware to be a function that returns the userId

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -365,9 +365,13 @@ exports = module.exports = function acl(redis, prefix){
       Error.call(this, msg);
       Error.captureStackTrace(this, arguments.callee);
     }
-    
+
     return function(req, res, next){
-      var _userId = userId
+      var _userId = userId;
+      // call function to fetch userId
+      if(typeof userId === 'function'){
+        _userId = userId(req, res);
+      }
       if (!userId) {
         if((req.session) && (req.session.userId)){
           _userId = req.session.userId


### PR DESCRIPTION
small modification that allows the caller of acl.middleware to provide a function in place of a userId that returns the userId.
