### PR TITLE
Changing permission denied error to 403

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -476,14 +476,19 @@ Acl.prototype.clean = function(callback){
   Express Middleware
 
 */
-Acl.prototype.middleware = function(numPathComponents, userId, actions){
-  contract(arguments)
-    .params()
-    .params('number')
-    .params('number','string|number|function')
-    .params('number','string|number|function', 'string|array')
-    .end();
+Acl.prototype.middleware = function(options){
+  // contract(arguments)
+  //   .params()
+  //   .params('number')
+  //   .params('number','string|number|function')
+  //   .params('number','string|number|function', 'string|array')
+  //   .end();
 
+  var numPathComponents = options.numPathComponents;
+  var userId = options.userId;
+  var actions = options.actions;
+  var prefix = options.prefix;
+  
   var acl = this;
 
   var HttpError = function(errorCode, msg){
@@ -513,6 +518,11 @@ Acl.prototype.middleware = function(numPathComponents, userId, actions){
     }
 
     url = req.url.split('?')[0];
+    
+    if(prefix){
+      url = url.replace(prefix,'');
+    }
+    
     if(!numPathComponents){
       resource = url;
     }else{


### PR DESCRIPTION
I'm changing the "Insufficient permissions" error to 403 because 401 is intended for users who are not authenticated. The 403, on the other hand, is intended for users who are authenticated, but are not permitted access to the resource.

http://stackoverflow.com/questions/3297048/403-forbidden-vs-401-unauthorized-http-responses

This caused issues in our ember application where that 401 response results in a redirect to the login page.
