### PR TITLE
Changing permission denied error to 403

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -533,7 +533,7 @@ Acl.prototype.middleware = function(numPathComponents, userId, actions){
         acl.allowedPermissions(_userId, resource, function(err, obj){
           acl.logger?acl.logger.debug('Allowed permissions: '+util.inspect(obj)):null;
         });
-        next(new HttpError(401,'Insufficient permissions to access resource'));
+        next(new HttpError(403,'Insufficient permissions to access resource'));
       }else{
         acl.logger?acl.logger.debug('Allowed '+actions+' on '+resource+' by user '+_userId):null;
         next();


### PR DESCRIPTION
This is my second attempt at pull request :)

I'm changing the "Insufficient permissions" error to 403 because 401 is intended for users who are not authenticated. The 403, on the other hand, is intended for users who are authorized, but are not permitted access to the resource.

http://stackoverflow.com/questions/3297048/403-forbidden-vs-401-unauthorized-http-responses
