### PR TITLE
hasRole rename - update readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -243,10 +243,10 @@ __Arguments__
 
 ---------------------------------------
 
-<a name="isInRole" />
-### isInRole( userId, rolename, function(err, is_in_role) )
+<a name="hasRole" />
+### hasRole( userId, rolename, function(err, hasRole) )
 
-Return boolean whether user is in the role
+Return boolean whether user has the role
 
 __Arguments__
   


### PR DESCRIPTION
`hasRole` function was renamed from `isInRole` as part of https://github.com/OptimalBits/node_acl/commit/e40c326a13f3a6fc81ff606bed68a585235bced3, but the README was not updated accordingly.
