### PR TITLE
Fix addRoleParents param descriptions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -266,8 +266,8 @@ Adds a parent or parent list to role.
 __Arguments__
 
 ```javascript
-    role     {String} User id.
-    parents  {String|Array} Role(s) to remove to the user id.
+    role     {String} Child role.
+    parents  {String|Array} Parent role(s) to be added.
     callback {Function} Callback called when finished.
 ```
 

--- a/lib/acl.js
+++ b/lib/acl.js
@@ -133,8 +133,8 @@ Acl.prototype.hasRole = function(userId, rolename, cb){
 
   Adds a parent or parent list to role.
 
-  @param {String|Number} User id.
-  @param {String|Array} Role(s) to remove to the user id.
+  @param {String} Child role.
+  @param {String|Array} Parent role(s) to be added.
   @param {Function} Callback called when finished.
   @return {Promise} Promise resolved when finished
 */


### PR DESCRIPTION
Parameter descriptions for `addRoleParents` look like they were copied from `removeUserRoles` and not updated.
