### PR TITLE
Give isAllowed() the ability to check if the either the user's id or their assigned roles provide access to a resource

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -306,6 +306,9 @@ __Arguments__
 
 Adds the given permissions to the given roles over the given resources.
 
+You can also assign a single user permissions on a resource by providing
+their userId instead of a role name.
+
 __Arguments__
   
 ```javascript
@@ -370,6 +373,9 @@ __Arguments__
   
 Checks if the given user is allowed to access the resource for the given 
 permissions (note: it must fulfill all the permissions).
+
+This will also check if the user has been granted access to the resource by
+using their userId as the role name.
 
 __Arguments__
   

--- a/lib/acl.js
+++ b/lib/acl.js
@@ -365,6 +365,9 @@ Acl.prototype.allowedPermissions = function(userId, resources, cb){
   Checks if the given user is allowed to access the resource for the given
   permissions (note: it must fulfill all the permissions).
 
+  Also check if the user exists as a role which has been given access
+  to the resource.
+
   @param {String|Number} User id.
   @param {String|Array} resource(s) to ask permissions for.
   @param {String|Array} asked permissions.
@@ -379,11 +382,8 @@ Acl.prototype.isAllowed = function(userId, resource, permissions, cb){
   var _this = this;
 
   return this.backend.getAsync('users', userId).then(function(roles){
-    if(roles.length){
-      return _this.areAnyRolesAllowed(roles, resource, permissions);
-    }else{
-      return false;
-    }
+    roles.push(userId);
+    return _this.areAnyRolesAllowed(roles, resource, permissions);
   }).nodeify(cb);
 };
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -124,6 +124,15 @@ exports.Allows = function () {
         done()
       })
     })
+
+    it('walter to view/edit/delete pages', function (done) {
+      var acl = new Acl(this.backend)
+
+      acl.allow('walter', 'pages', ['view','edit','delete'], function (err) {
+        assert(!err)
+        done()
+      })
+    })
   })
 
   describe('add role parents', function () {
@@ -293,7 +302,6 @@ exports.Allowance = function () {
         })
       })
 
-
       it('Can jsmith edit blogs?', function (done) {
         var acl = new Acl(this.backend)
 
@@ -451,6 +459,26 @@ exports.Allowance = function () {
         acl.isAllowed(4, 'forums', ['put','delete'], function (err, allow) {
           assert(!err)
           assert(allow)
+          done()
+        })
+      })
+
+      it('Can walter edit pages?', function (done) {
+        var acl = new Acl(this.backend)
+
+        acl.isAllowed('walter', 'pages', 'edit', function (err, allow) {
+          assert(!err)
+          assert(allow)
+          done()
+        })
+      })
+
+      it('Can joed edit pages?', function (done) {
+        var acl = new Acl(this.backend)
+
+        acl.isAllowed('joed', 'pages', 'edit', function (err, allow) {
+          assert(!err)
+          assert(!allow)
           done()
         })
       })


### PR DESCRIPTION
See issue: https://github.com/OptimalBits/node_acl/issues/76

When `isAllowed()` is called it will check if any of the user's permissions provide access to the resource, or if the user has been given access to the resource by using their userId as the role name.

This just avoids having to call both `isAllowed()` and `areAnyRolesAllowed()` to check is the user has access.
