### PR TITLE
fixes missing 'undefined'  check for 'permissions' in detecting the 'cb'

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -322,7 +322,7 @@ Acl.prototype.removeAllow = function(role, resources, permissions, cb){
     .end();
 
     resources = makeArray(resources);
-    if(cb || !_.isFunction(permissions)){
+    if(cb || (permissions && !_.isFunction(permissions))){
       permissions = makeArray(permissions);
     }else {
       cb = permissions;


### PR DESCRIPTION
invoking `.removeAllow` with a promise instead of a callback with no `permissions` parameter, as in `.removeAllow(role, resource).then( cb )`,  causes `.removePermissions` to be invoked with an empty array for `permissions` instead of `null`.  This then causes incorrect logic in that function's `if(permissions)` check and nothing gets removed instead of all permissions getting removed.   Need to check that `permission` is not `undefined` as well as being a `isFunction` in order to get the desired behavior.