### PR TITLE
Lazy loading backends

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
-module.exports = require("./lib/acl.js");
-module.exports.redisBackend = require("./lib/redis-backend.js");
-module.exports.memoryBackend = require("./lib/memory-backend.js");
-module.exports.mongodbBackend = require("./lib/mongodb-backend.js");
+module.exports = require('./lib/acl.js');
+module.exports.__defineGetter__('redisBackend', function(){
+  return require('./lib/redis-backend.js');
+});
+module.exports.__defineGetter__('memoryBackend', function(){
+  return require('./lib/memory-backend.js');
+});
+module.exports.__defineGetter__('mongodbBackend', function(){
+  return require('./lib/mongodb-backend.js');
+});


### PR DESCRIPTION
Usually there's only one backend used. So it's better not to load those unused backend drivers when not necessary. Consider if we use a plugin like node_acl_knex, all those built-in backend drivers should not be loaded at all then.