### PR TITLE
Fix object notation in array version of allow.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -337,7 +337,7 @@ __Arguments__
 
 ```javascript
     permissionsArray {Array} Array with objects expressing what permissions to give.
-       [{roles:{String|Array}, allows:[{resources:{String|Array}, permissions:{String|Array}]]
+       [{roles:{String|Array}, allows: {resources:{String|Array}, permissions:{String|Array}} ]
 
     callback         {Function} Callback called when finished.
 ```


### PR DESCRIPTION
I think the last part has an error with the object notation.