### PR TITLE
change req.url to req.originalUrl

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -389,6 +389,9 @@ Acl.prototype.removePermissions = function(role, resources, permissions, cb){
   @param {Function} Callback called when finished.
 */
 Acl.prototype.allowedPermissions = function(userId, resources, cb){
+  if (!userId)
+    return cb(null, []);
+
   contract(arguments)
     .params('string|number', 'string|array', 'function')
     .params('string|number', 'string|array')

--- a/lib/acl.js
+++ b/lib/acl.js
@@ -584,7 +584,7 @@ Acl.prototype.middleware = function(numPathComponents, userId, actions){
       return;
     }
 
-    url = req.url.split('?')[0];
+    url = req.originalUrl.split('?')[0];
     if(!numPathComponents){
       resource = url;
     }else{


### PR DESCRIPTION
I'm using Express 4 and `req.url` does not work. Example:

```javascript
router.get('/', acl.middleware())
app.use('/blog', router)
```

`req.url` is '/' but my real url is '/blog'
where `req.originalUrl` equals '/blog'