### PR TITLE
replaced bluebird.all with bluebird.reduce to call allow in sequence

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -639,9 +639,9 @@ Acl.prototype._allowEx = function(objs){
     });
   });
 
-  return bluebird.all(demuxed.map(function(obj){
+  return bluebird.reduce(demuxed, function(values, obj){
     return _this.allow(obj.roles, obj.resources, obj.permissions);
-  }));
+  }, null);
 };
 
 //


### PR DESCRIPTION
`_allowEx` was using `bluebird.all` to call the `allow` method, but this will call methods in parallel 
and can cause race conditions which might result in overriding some of the permissions.

`bluebird.reduce` will wait for a Promise to resolve before moving to the next element in the array
