### PR TITLE
Added the general regex flag to the encode_text

### DIFF
--- a/lib/mongodb-backend.js
+++ b/lib/mongodb-backend.js
@@ -189,7 +189,7 @@ MongoDBBackend.prototype = {
 function encodeText(text) {
   if (typeof text == 'string' || text instanceof String) {
     text = encodeURIComponent(text);
-    text = text.replace(/\./, '%2E');
+    text = text.replace(/\./g, '%2E');
   }
   return text;
 }


### PR DESCRIPTION
Just added the `g` flag in the text.replace to take care of all dots in the name, not just the first one.