### PR TITLE
don't call the cb twice in the same transaction

### DIFF
--- a/lib/mongodb-backend.js
+++ b/lib/mongodb-backend.js
@@ -128,14 +128,21 @@ MongoDBBackend.prototype = {
           if(err instanceof Error) return cb(err);
           cb(undefined);
         });
-              // Create index
-      collection.ensureIndex({_bucketname: 1, key: 1}, function(err){
-        if(err instanceof Error) {  return cb(err);
-        }else{   cb(undefined);
-      }
-      });
       });
     });
+
+    transaction.push(function(cb) {
+      self.db.collection(self.prefix + collName, function(err,collection){
+        // Create index
+        collection.ensureIndex({_bucketname: 1, key: 1}, function(err){
+          if (err instanceof Error) {
+            return cb(err);
+          } else{
+            cb(undefined);
+          }
+        });
+      });
+    })
   },
 
   /**


### PR DESCRIPTION
The async library complains if a callback is called twice in scope.

<img width="1121" alt="screen shot 2015-08-12 at 8 31 17 pm" src="https://cloud.githubusercontent.com/assets/847542/9240913/ee607a82-4131-11e5-8fff-620f4412f43b.png">
