### PR TITLE
Fix HttpError message reporting

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -589,13 +589,14 @@ Acl.prototype.middleware = function(numPathComponents, userId, actions){
 
   var acl = this;
 
-  var HttpError = function(errorCode, msg){
+  function HttpError(errorCode, msg){
     this.errorCode = errorCode;
-    this.msg = msg;
+    this.message = msg;
+    this.name = this.constructor.name;
 
-    Error.captureStackTrace(this, arguments);
-    Error.call(this, msg);
-  };
+    Error.captureStackTrace(this, this.constructor);
+    this.constructor.prototype.__proto__ = Error.prototype;
+  }
 
   return function(req, res, next){
     var _userId = userId,


### PR DESCRIPTION
The `HttpError`'s message currently renders as:

```
[object Object]
    at /acl-test/node_modules/acl/lib/acl.js:614:14
    at Layer.handle [as handle_request] (/acl-test/node_modules/express/lib/router/layer.js:95:5)
    at next (/acl-test/node_modules/express/lib/router/route.js:131:13)
```

This PR fixes the message. So that it renders properly. Tested on node v0.10 and v0.12. Here's what the fixed result looks like:

```
HttpError: User not authenticated
    at /acl-test/node_modules/acl/lib/acl.js:615:14
    at Layer.handle [as handle_request] (/acl-test/node_modules/express/lib/router/layer.js:95:5)
    at next (/acl-test/node_modules/express/lib/router/route.js:131:13)
```
