### PR TITLE
acl/middleware: add default errorHandler

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -655,6 +655,27 @@ Acl.prototype.middleware = function(numPathComponents, userId, actions){
   };
 };
 
+/**
+  Error handler for the Express middleware
+
+  @param {String} [contentType] (html|json) defaults to plain text
+*/
+Acl.prototype.middleware.errorHandler = function(contentType){
+  var method = 'end';
+
+  if(contentType){
+    switch (contentType) {
+      case 'json': method = 'json'; break;
+      case 'html': method = 'send'; break;
+    }
+  }
+
+  return function(err, req, res, next){
+    if(err.name !== 'HttpError' || !err.errorCode) return next(err);
+    res.status(err.errorCode)[method](err.message);
+  };
+};
+
 
 //-----------------------------------------------------------------------------
 //


### PR DESCRIPTION
This is a default error handler that can be used in conjunction with `acl.middleware()`.
It is a convenience method that allows to return the proper http status code and message, instead of the default 500 error.

Basic usage:

```js
app.get('/', acl.middleware(), function (req, res) { res.end('ok'); });
app.use(acl.middleware.errorHandler());
```

And a `curl` to this service will yield a clean http error with the correct status code and informative message:

```
$ curl -i http://localhost:3000/
HTTP/1.1 403 Forbidden
X-Powered-By: Express
Date: Sun, 23 Aug 2015 21:09:54 GMT
Connection: keep-alive
Transfer-Encoding: chunked

Insufficient permissions to access resource
```

Also supports `html` and `json` content type:

```js
app.get('/', acl.middleware(), function (req, res) { res.end('ok'); });
app.use(acl.middleware.errorHandler('json'));
```