### PR TITLE
acl/middleware: support `req.user.id` for userId

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -611,6 +611,8 @@ Acl.prototype.middleware = function(numPathComponents, userId, actions){
     if (!userId) {
       if((req.session) && (req.session.userId)){
         _userId = req.session.userId;
+      }else if((req.user) && (req.user.id)){
+        _userId = req.user.id;
       }else{
         next(new HttpError(401, 'User not authenticated'));
         return;


### PR DESCRIPTION
It's fairly common for express apps to have the logged-in user in `req.user`. This is shown in the [express docs](http://expressjs.com/api.html) as well as in the popular [Passport](http://passportjs.org/docs/authenticate) module (which exposes the user as `req.user`).

Thus, this change will make it easier to integrate `acl` with `Passport` and with non-browser-facing services (APIs) that don't use sessions (and do oauth instead, for example).