### PR TITLE
Allow removing prefix from URL by using negative number (middleware)

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -629,7 +629,11 @@ Acl.prototype.middleware = function(numPathComponents, userId, actions){
     if(!numPathComponents){
       resource = url;
     }else{
-      resource = url.split('/').slice(0,numPathComponents+1).join('/');
+      if(numPathComponents < 0){
+        resource = url.split('/').splice(numPathComponents).join('/');
+      }else{
+        resource = url.split('/').slice(0,numPathComponents+1).join('/');
+      }
     }
 
     if(!_actions){


### PR DESCRIPTION
Now, if we have a route like `/api/users`, we can remove the `api` prefix by passing a negative number to the `middleware` method; so, I'd do `middleware(-1)` to remove first part of the URL, or *-2* to remove first 2 pieces of the URL.