### PR TITLE
Get many optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/*
 .DS_Store
 *~
 .idea/
+.tags*

--- a/lib/acl.js
+++ b/lib/acl.js
@@ -65,7 +65,9 @@ var Acl = function (backend, logger, options){
   backend.getAsync = bluebird.promisify(backend.get);
   backend.cleanAsync = bluebird.promisify(backend.clean);
   backend.unionAsync = bluebird.promisify(backend.union);
-  backend.unionsAsync = bluebird.promisify(backend.unions);
+  if (backend.unions) {
+    backend.unionsAsync = bluebird.promisify(backend.unions);
+  }
 };
 
 /**
@@ -432,7 +434,7 @@ Acl.prototype.allowedPermissions = function(userId, resources, cb){
     .params('string|number', 'string|array')
     .end();
 
-  if (this.backend.unions) {
+  if (this.backend.unionsAsync) {
     return this.optimizedAllowedPermissions(userId, resources, cb);
   }
 

--- a/lib/acl.js
+++ b/lib/acl.js
@@ -65,6 +65,7 @@ var Acl = function (backend, logger, options){
   backend.getAsync = bluebird.promisify(backend.get);
   backend.cleanAsync = bluebird.promisify(backend.clean);
   backend.unionAsync = bluebird.promisify(backend.union);
+  backend.unionsAsync = bluebird.promisify(backend.unions);
 };
 
 /**
@@ -424,12 +425,16 @@ Acl.prototype.removePermissions = function(role, resources, permissions, cb){
 */
 Acl.prototype.allowedPermissions = function(userId, resources, cb){
   if (!userId)
-    return cb(null, []);
+    return cb(null, {});
 
   contract(arguments)
     .params('string|number', 'string|array', 'function')
     .params('string|number', 'string|array')
     .end();
+
+  if (this.backend.unions) {
+    return this.optimizedAllowedPermissions(userId, resources, cb);
+  }
 
   var _this = this;
   resources = makeArray(resources);
@@ -443,6 +448,55 @@ Acl.prototype.allowedPermissions = function(userId, resources, cb){
     })).then(function(){
       return result;
     });
+  }).nodeify(cb);
+};
+
+/**
+  optimizedAllowedPermissions( userId, resources, function(err, obj) )
+
+  Returns all the allowable permissions a given user have to
+  access the given resources.
+
+  It returns a map of resource name to a list of permissions for that resource.
+
+  This is the same as allowedPermissions, it just takes advantage of the unions
+  function if available to reduce the number of backend queries.
+
+  @param {String|Number} User id.
+  @param {String|Array} resource(s) to ask permissions for.
+  @param {Function} Callback called when finished.
+*/
+Acl.prototype.optimizedAllowedPermissions = function(userId, resources, cb){
+  if (!userId) {
+    return cb(null, {});
+  }
+
+  contract(arguments)
+    .params('string|number', 'string|array', 'function|undefined')
+    .params('string|number', 'string|array')
+    .end();
+
+  resources = makeArray(resources);
+  var self = this;
+
+  return this._allUserRoles(userId).then(function(roles) {
+    var buckets = resources.map(allowsBucket);
+    if (roles.length === 0) {
+      var emptyResult = {};
+      buckets.forEach(function(bucket) {
+        emptyResult[bucket] = [];
+      });
+      return bluebird.resolve(emptyResult);
+    }
+
+    return self.backend.unionsAsync(buckets, roles);
+  }).then(function(response) {
+    var result = {};
+    Object.keys(response).forEach(function(bucket) {
+      result[keyFromAllowsBucket(bucket)] = response[bucket];
+    });
+
+    return result;
   }).nodeify(cb);
 };
 
@@ -644,7 +698,7 @@ Acl.prototype.middleware = function(numPathComponents, userId, actions){
       }else if(allowed === false){
         if (acl.logger) {
           acl.logger.debug('Not allowed '+_actions+' on '+resource+' by user '+_userId);
-          acl.allowedPermissions(_userId, resource, function(err, obj){		
+          acl.allowedPermissions(_userId, resource, function(err, obj){
             acl.logger.debug('Allowed permissions: '+util.inspect(obj));
           });
         }
@@ -748,7 +802,7 @@ Acl.prototype._allRoles = function(roleNames, cb){
 // Return all roles in the hierarchy including the given roles.
 //
 Acl.prototype._allRoles = function(roleNames){
-  var _this = this, roles;
+  var _this = this;
 
   return this._rolesParents(roleNames).then(function(parents){
     if(parents.length > 0){
@@ -757,6 +811,21 @@ Acl.prototype._allRoles = function(roleNames){
       });
     }else{
       return roleNames;
+    }
+  });
+};
+
+//
+// Return all roles in the hierarchy of the given user.
+//
+Acl.prototype._allUserRoles = function(userId) {
+  var _this = this;
+
+  return this.userRoles(userId).then(function(roles) {
+    if (roles && roles.length > 0) {
+      return _this._allRoles(roles);
+    } else {
+      return [];
     }
   });
 };
@@ -848,10 +917,12 @@ function allowsBucket(role){
   return 'allows_'+role;
 }
 
+function keyFromAllowsBucket(str) {
+  return str.replace(/^allows_/, '');
+}
+
 
 // -----------------------------------------------------------------------------------
 
 
 exports = module.exports = Acl;
-
-

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -39,12 +39,12 @@ var Backend = {
   },
 
   /**
-     Gets the contents of the specified keys and returns them in the same order
-     passed.
+     Gets the union of contents of the specified keys in each of the specified buckets and returns
+     a mapping of bucket to union.
   */
-  getAll : function(bucket, keys, cb){
+  unions : function(bucket, keys, cb){
     contract(arguments)
-        .params('string', 'array', 'function')
+        .params('array', 'array', 'function')
         .end();
   },
 

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -1,78 +1,88 @@
 /**
-	Backend Interface.
-	
-	Implement this API for providing a backend for the acl module.
+  Backend Interface.
+
+  Implement this API for providing a backend for the acl module.
 */
 
 var contract = require('./contract');
 
 var Backend = {
-  /**  
+  /**
      Begins a transaction.
   */
   begin : function(){
     // returns a transaction object
   },
-  
+
   /**
      Ends a transaction (and executes it)
   */
   end : function(transaction, cb){
-		contract(arguments).params('object', 'function').end();
+    contract(arguments).params('object', 'function').end();
     // Execute transaction
   },
-  
+
   /**
     Cleans the whole storage.
   */
   clean : function(cb){
     contract(arguments).params('function').end();
   },
-  
+
   /**
      Gets the contents at the bucket's key.
   */
   get : function(bucket, key, cb){
-		contract(arguments)
-	      .params('string', 'string|number', 'function')
-	      .end();
+    contract(arguments)
+        .params('string', 'string|number', 'function')
+        .end();
   },
 
-	/**
-		Returns the union of the values in the given keys.
-	*/
+  /**
+     Gets the contents of the specified keys and returns them in the same order
+     passed.
+  */
+  getAll : function(bucket, keys, cb){
+    contract(arguments)
+        .params('string', 'array', 'function')
+        .end();
+  },
+
+  /**
+    Returns the union of the values in the given keys.
+  */
   union : function(bucket, keys, cb){
     contract(arguments)
-  	  .params('string', 'array', 'function')
-  	  .end();
-	},
-  
+      .params('string', 'array', 'function')
+      .end();
+  },
+
   /**
-		Adds values to a given key inside a bucket.
-	*/
-	add : function(transaction, bucket, key, values){
-		contract(arguments)
-	      .params('object', 'string', 'string|number','string|array|number')
+    Adds values to a given key inside a bucket.
+  */
+  add : function(transaction, bucket, key, values){
+    contract(arguments)
+        .params('object', 'string', 'string|number','string|array|number')
         .end();
-	},
-    
+  },
+
   /**
      Delete the given key(s) at the bucket
   */
   del : function(transaction, bucket, keys){
-		contract(arguments)
-	      .params('object', 'string', 'string|array')
-	      .end();
-  },
-  
-	/**
-		Removes values from a given key inside a bucket.
-	*/
-	remove : function(transaction, bucket, key, values){
-		contract(arguments)
-	      .params('object', 'string', 'string|number','string|array|number')
+    contract(arguments)
+        .params('object', 'string', 'string|array')
         .end();
-	},
+  },
+
+  /**
+    Removes values from a given key inside a bucket.
+  */
+  remove : function(transaction, bucket, key, values){
+    contract(arguments)
+        .params('object', 'string', 'string|number','string|array|number')
+        .end();
+  },
 }
 
 exports = module.exports = Backend;

--- a/lib/memory-backend.js
+++ b/lib/memory-backend.js
@@ -60,6 +60,21 @@ MemoryBackend.prototype = {
   },
 
   /**
+     Gets the contents at the bucket's keys.
+  */
+  getAll : function(bucket, keys, cb){
+    contract(arguments)
+        .params('string', 'array', 'function')
+        .end();
+
+    if(this._buckets[bucket]){
+      cb(null, _.pick(this._buckets[bucket], keys));
+    }else{
+      cb(null, {});
+    }
+  },
+
+  /**
     Returns the union of the values in the given keys.
   */
   union : function(bucket, keys, cb){

--- a/lib/memory-backend.js
+++ b/lib/memory-backend.js
@@ -60,18 +60,25 @@ MemoryBackend.prototype = {
   },
 
   /**
-     Gets the contents at the bucket's keys.
+     Gets the union of the keys in each of the specified buckets
   */
-  getAll : function(bucket, keys, cb){
+  unions : function(buckets, keys, cb){
     contract(arguments)
-        .params('string', 'array', 'function')
+        .params('array', 'array', 'function')
         .end();
 
-    if(this._buckets[bucket]){
-      cb(null, _.pick(this._buckets[bucket], keys));
-    }else{
-      cb(null, {});
-    }
+    var self = this;
+    var results = {};
+
+    buckets.forEach(function(bucket) {
+      if(self._buckets[bucket]){
+        results[bucket] = _.uniq(_.flatten(_.values(_.pick(self._buckets[bucket], keys))));
+      }else{
+        results[bucket] = [];
+      }
+    });
+
+    cb(null, results);
   },
 
   /**

--- a/lib/redis-backend.js
+++ b/lib/redis-backend.js
@@ -61,23 +61,23 @@ RedisBackend.prototype = {
   },
 
   /**
-    Gets an array of the contents of the specified keys.
+    Gets an object mapping each passed bucket to the union of the specified keys inside that bucket.
   */
-  getAll : function(bucket, keys, cb){
+  unions : function(buckets, keys, cb){
     contract(arguments)
-      .params('string', 'array', 'function')
+      .params('array', 'array', 'function')
       .end();
 
-    var redisKeys = this.bucketKey(bucket, keys);
+    var redisKeys = {};
     var batch = this.redis.batch();
     var self = this;
-
-    redisKeys.map(function(key) {
-      batch.smembers(key, self.redis.print);
+    buckets.forEach(function(bucket) {
+      redisKeys[bucket] = self.bucketKey(bucket, keys);
+      batch.sunion(redisKeys[bucket], noop);
     });
 
     batch.exec(function(err, replies) {
-      var result = Array.isArray(replies) ? _.zipObject(keys, replies) : replies;
+      var result = Array.isArray(replies) ? _.zipObject(buckets, replies) : {};
       cb(err, result);
     });
   },

--- a/lib/redis-backend.js
+++ b/lib/redis-backend.js
@@ -1,11 +1,12 @@
 /**
 	Redis Backend.
-	
+
   Implementation of the storage backend using Redis
 */
 "use strict";
 
 var contract = require('./contract');
+var _ = require('lodash');
 
 function noop(){};
 
@@ -15,14 +16,14 @@ function RedisBackend(redis, prefix){
 }
 
 RedisBackend.prototype = {
-  
-  /**  
+
+  /**
      Begins a transaction
   */
   begin : function(){
     return this.redis.multi();
   },
-  
+
   /**
      Ends a transaction (and executes it)
   */
@@ -30,7 +31,7 @@ RedisBackend.prototype = {
 		contract(arguments).params('object', 'function').end();
     transaction.exec(function(){cb()});
   },
-  
+
   /**
     Cleans the whole storage.
   */
@@ -45,7 +46,7 @@ RedisBackend.prototype = {
       }
     });
   },
-  
+
   /**
      Gets the contents at the bucket's key.
   */
@@ -55,10 +56,32 @@ RedisBackend.prototype = {
 	      .end();
 
     key = this.bucketKey(bucket, key);
-    
+
     this.redis.smembers(key, cb);
   },
-  
+
+  /**
+    Gets an array of the contents of the specified keys.
+  */
+  getAll : function(bucket, keys, cb){
+    contract(arguments)
+      .params('string', 'array', 'function')
+      .end();
+
+    var redisKeys = this.bucketKey(bucket, keys);
+    var batch = this.redis.batch();
+    var self = this;
+
+    redisKeys.map(function(key) {
+      batch.smembers(key, self.redis.print);
+    });
+
+    batch.exec(function(err, replies) {
+      var result = Array.isArray(replies) ? _.zipObject(keys, replies) : replies;
+      cb(err, result);
+    });
+  },
+
 	/**
 		Returns the union of the values in the given keys.
 	*/
@@ -66,11 +89,11 @@ RedisBackend.prototype = {
 		contract(arguments)
 	      .params('string', 'array', 'function')
 	      .end();
-    
+
     keys = this.bucketKey(bucket, keys);
     this.redis.sunion(keys, cb);
 	},
-  
+
 	/**
 		Adds values to a given key inside a bucket.
 	*/
@@ -78,9 +101,9 @@ RedisBackend.prototype = {
 		contract(arguments)
 	      .params('object', 'string', 'string|number','string|array|number')
         .end();
-            
+
     key = this.bucketKey(bucket, key);
-            
+
     if (Array.isArray(values)){
       values.forEach(function(value){
         transaction.sadd(key, value);
@@ -89,7 +112,7 @@ RedisBackend.prototype = {
       transaction.sadd(key, values);
     }
 	},
-  
+
   /**
      Delete the given key(s) at the bucket
   */
@@ -97,18 +120,18 @@ RedisBackend.prototype = {
 		contract(arguments)
 	      .params('object', 'string', 'string|array')
 	      .end();
-            
+
     var self = this;
-    
+
     keys = Array.isArray(keys) ? keys : [keys]
-    
+
     keys = keys.map(function(key){
       return self.bucketKey(bucket, key);
     });
-  
+
     transaction.del(keys);
   },
-  
+
 	/**
 		Removes values from a given key inside a bucket.
 	*/
@@ -116,9 +139,9 @@ RedisBackend.prototype = {
 		contract(arguments)
 	      .params('object', 'string', 'string|number','string|array|number')
         .end();
-                  
+
     key = this.bucketKey(bucket, key);
-        
+
     if (Array.isArray(values)){
       values.forEach(function(value){
         transaction.srem(key, value);
@@ -127,11 +150,11 @@ RedisBackend.prototype = {
       transaction.srem(key, values);
     }
   },
-  
+
   //
   // Private methods
   //
-    
+
   bucketKey : function(bucket, keys){
     var self = this;
     if(Array.isArray(keys)){

--- a/lib/redis-backend.js
+++ b/lib/redis-backend.js
@@ -71,13 +71,25 @@ RedisBackend.prototype = {
     var redisKeys = {};
     var batch = this.redis.batch();
     var self = this;
+
     buckets.forEach(function(bucket) {
       redisKeys[bucket] = self.bucketKey(bucket, keys);
       batch.sunion(redisKeys[bucket], noop);
     });
 
     batch.exec(function(err, replies) {
-      var result = Array.isArray(replies) ? _.zipObject(buckets, replies) : {};
+      if (!Array.isArray(replies)) {
+        return {};
+      }
+
+      var result = {};
+      replies.forEach(function(reply, index) {
+        if (reply instanceof Error) {
+          throw reply;
+        }
+
+        result[buckets[index]] = reply;
+      });
       cb(err, result);
     });
   },

--- a/test/backendtests.js
+++ b/test/backendtests.js
@@ -1,0 +1,58 @@
+var chai = require('chai');
+var assert = chai.assert;
+var expect = chai.expect;
+var _ = require('lodash');
+
+var testData = {
+  key1: ["1", "2", "3"],
+  key2: ["4", "5", "6"],
+  key3: ["7", "8", "9"]
+};
+var bucket = 'test-bucket';
+
+exports.getAll = function() {
+  describe('getAll', function() {
+    before(function(done) {
+      var backend = this.backend;
+      if (!backend.getAll) {
+        this.skip();
+      }
+
+      backend.clean(function() {
+        var transaction = backend.begin();
+        Object.keys(testData).forEach(function(key) {
+          backend.add(transaction, bucket, key, testData[key]);
+        });
+        backend.end(transaction, done);
+      });
+    });
+
+    after(function(done) {
+      this.backend.clean(done);
+    });
+
+    it('should respond with an appropriate map', function(done) {
+      this.backend.getAll(bucket, Object.keys(testData), function(err, result) {
+        expect(err).to.be.null;
+        expect(result).to.be.eql(testData);
+        done();
+      });
+    });
+
+    it('should get only the specified keys', function(done) {
+      this.backend.getAll(bucket, ['key1'], function(err, result) {
+        expect(err).to.be.null;
+        expect(result).to.be.eql(_.pick(testData, 'key1'));
+        done();
+      });
+    });
+
+    it('should be order-independent', function(done) {
+      this.backend.getAll(bucket, Object.keys(testData).reverse(), function(err, result) {
+        expect(err).to.be.null;
+        expect(result).to.be.eql(testData);
+        done();
+      });
+    });
+  });
+};

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,5 +1,6 @@
 var Acl = require('../')
   , tests = require('./tests')
+  , backendTests = require('./backendtests');
 
 describe('MongoDB - Default', function () {
   before(function (done) {
@@ -43,22 +44,22 @@ describe('Redis', function () {
           password: null
         }
       , Redis = require('redis')
-        
-        
+
+
     var redis = Redis.createClient(options.port, options.host,  {no_ready_check: true} )
 
     function start(){
       self.backend = new Acl.redisBackend(redis)
       done()
     }
-    
+
     if (options.password) {
       redis.auth(options.password, start)
     } else {
       start()
     }
   })
-  
+
   run()
 })
 
@@ -68,7 +69,7 @@ describe('Memory', function () {
     var self = this
       self.backend = new Acl.memoryBackend()
   })
-  
+
   run()
 })
 
@@ -76,4 +77,8 @@ function run() {
   Object.keys(tests).forEach(function (test) {
     tests[test]()
   })
+
+  Object.keys(backendTests).forEach(function (test) {
+    backendTests[test]()
+  });
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -619,6 +619,17 @@ exports.Allowance = function () {
           done()
         })
       })
+      it('What permissions has nonsenseUser over blogs and forums?', function (done) {
+        var acl = new Acl(this.backend)
+        acl.allowedPermissions('nonsense', ['blogs','forums'], function (err, permissions) {
+          assert(!err)
+
+          assert(permissions.forums.length === 0)
+          assert(permissions.blogs.length === 0)
+
+          done()
+        })
+      })
     })
   })
 }


### PR DESCRIPTION
Implement a `unions` function for redis and in-memory backends which, in the case of redis-backend, pipelines a series of unions. According to the node_redis docs this represents a 400% speed-up over calling the functions in a loop.

Implements an optimized implementation of `allowedPermissions` to take advantage of the new method. This calculates the list of roles the user has in advance, and then makes the pipelined calls to fetch all of the permissions. Where previously this method was making `d * n` calls (where `d` is the depth of the role tree, and `n` is the number of resources being queried) it now makes `d` calls, plus `n` in a single pipeline. This should be a speedup overall of something like `d * 400%` which in our case could easily be something like `1600%`.

Note: I initially thought that this was going to be even better (resulting in `d + 1` calls) by using `MGET`, but there is no set-based equivalent of `MGET`, unless you consider `SUNION` to be analogous, which it sort of is. I had to fall back to pipelining, which is still a lot better.

Overall there are some massive performance and robustness improvements that could be made here, but I think that this will be a good enough start to make our approach feasible.