### PR TITLE
Fix a missing parenthesis in the first example for isAllowed().

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -140,7 +140,7 @@ acl.isAllowed('joed', 'blogs', 'view', function(err, res){
     if(res){
         console.log("User joed is allowed to view blogs")
     }
-}
+})
 ```
 
 


### PR DESCRIPTION
Was running through the sample code in the readme and came across this missing parenthesis.  Cheers!