### PR TITLE
Add link to sequelize backend to readme.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,13 @@ Create roles and assign roles to users. Sometimes it may even be useful to creat
 to get the finest granularity possible, while in other situations you will give the *asterisk* permission
 for admin kind of functionality.
 
-A Redis, MongoDB and In-Memory based backends are provided built-in in the module. There are other third party backends such as [*knex*](https://github.com/christophertrudel/node_acl_knex) based and [*firebase*](https://github.com/tonila/node_acl_firebase). There is also an alternative memory backend that supports [*regexps*](https://github.com/futurechan/node_acl-mem-regexp).
+A Redis, MongoDB and In-Memory based backends are provided built-in in the module. There are other third party backends such as
+
+* [*knex*](https://github.com/christophertrudel/node_acl_knex)
+* [*sequelize*](https://github.com/kristijanhusak/node_acl_sequelize)
+* [*firebase*](https://github.com/tonila/node_acl_firebase)
+
+There is also an alternative memory backend that supports [*regexps*](https://github.com/futurechan/node_acl-mem-regexp).
 
 Follow [manast](http://twitter.com/manast) for news and updates regarding this library.
 


### PR DESCRIPTION
Hi,

I created Sequelize backend implementation (Only Postgres for now), and i want to add reference to it.

I know there is already Knex implementation that does the same thing, but i didn't want to use another ORM just to be able to use acl.