### PR TITLE
chore(npm): update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
   },
   "main": "./index.js",
   "dependencies": {
-    "async": "^1.5.0",
-    "bluebird": "^3.0.2",
-    "lodash": "^3.10.1",
-    "mongodb": "^2.0.47",
-    "redis": "^2.2.5"
+    "async": "^2.0.1",
+    "bluebird": "^3.4.1",
+    "lodash": "^4.15.0",
+    "mongodb": "^2.2.6",
+    "redis": "^2.6.2"
   },
   "devDependencies": {
-    "mocha": "^2.3.3",
-    "chai": "^3.4.0"
+    "mocha": "^2.5.3",
+    "chai": "^3.5.0"
   },
   "scripts": {
     "test": "mocha test/runner.js --reporter spec",


### PR DESCRIPTION
Upgrade npm depedencies to latest versions except for mocha (^2.5.3).

Indeed, running tests with mocha 3 leads to some errors:
```
1) MongoDB - Default unions "before all" hook:
     Error: done() called multiple times
      at Suite.<anonymous> (test/backendtests.js:15:5)
      at Object.exports.unions (test/backendtests.js:14:3)
      at test/runner.js:82:23
      at Array.forEach (native)
      at run (test/runner.js:81:29)
      at Suite.<anonymous> (test/runner.js:18:3)
      at Object.<anonymous> (test/runner.js:5:1)
      at require (internal/module.js:20:19)
      at Array.forEach (native)
      at run (bootstrap_node.js:352:7)
      at startup (bootstrap_node.js:144:9)
      at bootstrap_node.js:467:3

  2) MongoDB - useSingle unions "before all" hook:
     Error: done() called multiple times
      at Suite.<anonymous> (test/backendtests.js:15:5)
      at Object.exports.unions (test/backendtests.js:14:3)
      at test/runner.js:82:23
      at Array.forEach (native)
      at run (test/runner.js:81:29)
      at Suite.<anonymous> (test/runner.js:35:3)
      at Object.<anonymous> (test/runner.js:22:1)
      at require (internal/module.js:20:19)
      at Array.forEach (native)
      at run (bootstrap_node.js:352:7)
      at startup (bootstrap_node.js:144:9)
      at bootstrap_node.js:467:3
```