### PR TITLE
acl.middleware numPathComponents support Function type

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -636,9 +636,9 @@ Acl.prototype.clean = function(callback){
 Acl.prototype.middleware = function(numPathComponents, userId, actions){
   contract(arguments)
     .params()
-    .params('number')
-    .params('number','string|number|function')
-    .params('number','string|number|function', 'string|array')
+    .params('number|function')
+    .params('number|function','string|number|function')
+    .params('number|function','string|number|function', 'string|array')
     .end();
 
   var acl = this;

--- a/lib/acl.js
+++ b/lib/acl.js
@@ -683,7 +683,11 @@ Acl.prototype.middleware = function(numPathComponents, userId, actions){
     if(!numPathComponents){
       resource = url;
     }else{
-      resource = url.split('/').slice(0,numPathComponents+1).join('/');
+      if(typeof numPathComponents === 'function'){
+        resource = numPathComponents.bind(req)(url);
+      }else{
+        resource = url.split('/').slice(0,numPathComponents+1).join('/');
+      }
     }
 
     if(!_actions){


### PR DESCRIPTION
When cooperation with some routing module, like koa-router. the default implementation, can not meet all of the scenarios. by providing functions for greater flexibility.