### PR TITLE
Problem when any of ACL Middleware argument is null or undefined | Solved

### DIFF
--- a/lib/contract.js
+++ b/lib/contract.js
@@ -68,17 +68,20 @@ var checkParams = function(args, contract){
       }catch(e){
         console.log(e, args)
       }
-      
-      type = typeOf(args[i]);
-      fulfilled = false;
-      for(j=0; j<types.length; j++){
-        if (type === types[j]){
-          fulfilled = true;
-          break;
+      if (!args[i]) {
+        fulfilled = true;
+      } else {
+        type = typeOf(args[i]);
+        fulfilled = false;
+        for(j=0; j<types.length; j++){
+          if (type === types[j]){
+            fulfilled = true;
+            break;
+          }
         }
-      }
-      if(fulfilled===false){
-        return false;
+        if(fulfilled===false){
+          return false;
+        }
       }
     }
     return true;

--- a/lib/contract.js
+++ b/lib/contract.js
@@ -68,9 +68,7 @@ var checkParams = function(args, contract){
       }catch(e){
         console.log(e, args)
       }
-      if (!args[i]) {
-        fulfilled = true;
-      } else {
+      if (args[i]) {
         type = typeOf(args[i]);
         fulfilled = false;
         for(j=0; j<types.length; j++){
@@ -79,9 +77,9 @@ var checkParams = function(args, contract){
             break;
           }
         }
-        if(fulfilled===false){
-          return false;
-        }
+      }
+      if(fulfilled===false){
+        return false;
       }
     }
     return true;


### PR DESCRIPTION
**This is the solution for my the issue #212 I had filed earlier**

In my used case, I wanted to send a custom userId and it was breaking down and the middleware throws Broke parameter contract. 
Problem was with the contract.js code in which, in the checkParams function, it straight-away starts comparing the type of incoming arguments with the allowed contract types

Old Code:-

```
      type = typeOf(args[i]);
      fulfilled = false;
      for(j=0; j<types.length; j++){
        if (type === types[j]){
          fulfilled = true;
          break;
        }
      }
      if(fulfilled===false){
        return false;
      }
    }
```

New Code:-

```
      if (args[i]) {
        type = typeOf(args[i]);
        fulfilled = false;
        for(j=0; j<types.length; j++){
          if (type === types[j]){
            fulfilled = true;
            break;
          }
        }
      }
      if(fulfilled===false){
        return false;
      }
    }
```

After this, this works perfectly. This is pretty common issue people must be facing since, one might need to send a custom userId or actions without specifying numPathComponents
