### PR TITLE
Fix Markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#NODE ACL - Access Control Lists for Node
+# NODE ACL - Access Control Lists for Node
 
 This module provides a minimalistic ACL implementation inspired by Zend_ACL.
 
@@ -14,13 +14,13 @@ A Redis, MongoDB and In-Memory based backends are provided built-in in the modul
 
 Follow [manast](http://twitter.com/manast) for news and updates regarding this library.
 
-##Status
+## Status
 
 [![BuildStatus](https://secure.travis-ci.org/OptimalBits/node_acl.png?branch=master)](http://travis-ci.org/OptimalBits/node_acl)
 [![Dependency Status](https://david-dm.org/OptimalBits/node_acl.svg)](https://david-dm.org/OptimalBits/node_acl)
 [![devDependency Status](https://david-dm.org/OptimalBits/node_acl/dev-status.svg)](https://david-dm.org/OptimalBits/node_acl#info=devDependencies)
 
-##Features
+## Features
 
 - Users
 - Roles
@@ -57,7 +57,7 @@ npm install acl
 * [middleware](#middleware)
 * [backend](#backend)
 
-##Examples
+## Examples
 
 Create your acl module by requiring it and instantiating it with a valid backend instance:
 
@@ -205,6 +205,7 @@ app.put('/blogs/:id/comments/:commentId', acl.middleware(3, 'joed', 'post'), fun
 ## Methods
 
 <a name="addUserRoles"/>
+
 ### addUserRoles( userId, roles, function(err) )
 
 Adds roles to a given user id.
@@ -220,6 +221,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="removeUserRoles"/>
+
 ### removeUserRoles( userId, roles, function(err) )
 
 Remove roles from a given user.
@@ -235,6 +237,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="userRoles" />
+
 ### userRoles( userId, function(err, roles) )
 
 Return all the roles from a given user.
@@ -249,6 +252,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="roleUsers" />
+
 ### roleUsers( rolename, function(err, users) )
 
 Return all users who has a given role.
@@ -263,6 +267,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="hasRole" />
+
 ### hasRole( userId, rolename, function(err, hasRole) )
 
 Return boolean whether user has the role
@@ -278,6 +283,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="addRoleParents" />
+
 ### addRoleParents( role, parents, function(err) )
 
 Adds a parent or parent list to role.
@@ -293,6 +299,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="removeRoleParents" />
+
 ### removeRoleParents( role, parents, function(err) )
 
 Removes a parent or parent list from role.
@@ -310,6 +317,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="removeRole" />
+
 ### removeRole( role, function(err) )
 
 Removes a role from the system.
@@ -338,6 +346,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="allow" />
+
 ### allow( roles, resources, permissions, function(err) )
 
 Adds the given permissions to the given roles over the given resources.
@@ -365,6 +374,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="removeAllow" />
+
 ###  removeAllow( role, resources, permissions, function(err) )
 
 Remove permissions from the given roles owned by the given role.
@@ -383,6 +393,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="allowedPermissions" />
+
 ### allowedPermissions( userId, resources, function(err, obj) )
 
 Returns all the allowable permissions a given user have to
@@ -402,6 +413,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="isAllowed" />
+
 ### isAllowed( userId, resource, permissions, function(err, allowed) )
 
 Checks if the given user is allowed to access the resource for the given
@@ -418,6 +430,7 @@ __Arguments__
 
 ---------------------------------------
 <a name="areAnyRolesAllowed" />
+
 ### areAnyRolesAllowed( roles, resource, permissions, function(err, allowed) )
 
 Returns true if any of the given roles have the right permissions.
@@ -433,6 +446,7 @@ __Arguments__
 
 ---------------------------------------
 <a name="whatResources" />
+
 ### whatResources(role, function(err, {resourceName: [permissions]})
 
 Returns what resources a given role has permissions over.
@@ -459,6 +473,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="middleware" />
+
 ### middleware( [numPathComponents, userId, permissions] )
 
 Middleware for express.
@@ -476,6 +491,7 @@ __Arguments__
 ---------------------------------------
 
 <a name="backend" />
+
 ### backend( db, [prefix] )
 
 Creates a backend instance. All backends except Memory require driver or database instance. `useSingle` is only applicable to the MongoDB backend.
@@ -504,7 +520,7 @@ var redisBackend = new acl.redisBackend(client);
 
 Creates a new Redis backend using Redis client `client`.
 
-##Tests
+## Tests
 
 Run tests with `npm` (requires mocha):
 ```javascript
@@ -516,7 +532,7 @@ Run tests with `npm` (requires mocha):
 - Support for denials (deny a role a given permission)
 
 
-##License
+## License
 
 (The MIT License)
 


### PR DESCRIPTION
At least for "GitHub Flavored Markdown," there must be a space after the `#` in a header, and blank lines before and after it.