### PR TITLE
More information on middleware() log

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -690,7 +690,9 @@ Acl.prototype.middleware = function(numPathComponents, userId, actions){
       _actions = req.method.toLowerCase();
     }
 
-    acl.logger?acl.logger.debug('Requesting '+_actions+' on '+resource+' by user '+_userId):null;
+    if (acl.logger){
+      acl.logger.debug('Requesting '+_actions+' on '+resource+' by user '+_userId+' (request url:'+url+')');
+    }
 
     acl.isAllowed(_userId, resource, _actions, function(err, allowed){
       if (err){


### PR DESCRIPTION
Adds sanitized originalUrl to the logging of resource action.

This helps a lot, whenever a developer wants to check if `numPathComponents` is well defined.