### PR TITLE
Replace deprecated collection methods in mongodb-backend.js. Fixes #270

### DIFF
--- a/lib/mongodb-backend.js
+++ b/lib/mongodb-backend.js
@@ -125,7 +125,7 @@ MongoDBBackend.prototype = {
         values.forEach(function(value){doc[value]=true;});
 
         // update document
-        collection.update(updateParams,{$set:doc},{safe:true,upsert:true},function(err){
+        collection.updateOne(updateParams, {$set:doc}, {w:1, upsert:true}, function(err){
           if(err instanceof Error) return cb(err);
           cb(undefined);
         });
@@ -135,7 +135,7 @@ MongoDBBackend.prototype = {
     transaction.push(function(cb) {
       self.db.collection(self.prefix + self.removeUnsupportedChar(collName), function(err,collection){
         // Create index
-        collection.ensureIndex({_bucketname: 1, key: 1}, function(err){
+        collection.createIndex({_bucketname: 1, key: 1}, function(err){
           if (err instanceof Error) {
             return cb(err);
           } else{
@@ -161,7 +161,7 @@ MongoDBBackend.prototype = {
     transaction.push(function(cb){
       self.db.collection(self.prefix + self.removeUnsupportedChar(collName),function(err,collection){
         if(err instanceof Error) return cb(err);
-        collection.remove(updateParams,{safe:true},function(err){
+        collection.deleteMany(updateParams, {w:1}, function(err){
           if(err instanceof Error) return cb(err);
           cb(undefined);
         });
@@ -191,7 +191,7 @@ MongoDBBackend.prototype = {
         values.forEach(function(value){doc[value]=true;});
 
         // update document
-        collection.update(updateParams,{$unset:doc},{safe:true,upsert:true},function(err){
+        collection.updateOne(updateParams, {$unset:doc}, {w:1, upsert:true}, function(err){
           if(err instanceof Error) return cb(err);
           cb(undefined);
         });


### PR DESCRIPTION
Converts the deprecated collection methods and write concern setting to align with v2.0 and v3.1 of the MongoDB Driver APIs.